### PR TITLE
Added semicolon as separator

### DIFF
--- a/cb_utils/data.py
+++ b/cb_utils/data.py
@@ -37,7 +37,7 @@ def load_participants(path: Path) -> pl.DataFrame:
     }
     return (
         pl
-        .read_csv(path, infer_schema_length=20000)
+        .read_csv(path, separator=";", infer_schema_length=20000)
         .rename(column_mapping)
         .with_columns(
             pl.col("name").str.strip().str.to_uppercase()


### PR DESCRIPTION
When the user saves an .xls as .csv on Dutch Windows installations, the delimiter is automatically set to ';'. It is not trivial for basic users to change this, so it would be great if the script could handle this instead.