### PR TITLE
Feature: use semi as separator for expectations

### DIFF
--- a/cb_utils/data.py
+++ b/cb_utils/data.py
@@ -59,7 +59,7 @@ def load_expectations(path: Path) -> pl.DataFrame:
     """Columns: survey,page,expected word,,"""
     return (
         pl
-        .read_csv(path, separator=",", infer_schema_length=20000, truncate_ragged_lines=True)
+        .read_csv(path, separator=";", infer_schema_length=20000, truncate_ragged_lines=True)
     )
 
 @dataclass


### PR DESCRIPTION
For consistency's sake. Now all four input files are interpreted using semicolons as a field delimiter.